### PR TITLE
gradle-wrapper.properties is missing distributionSha256Sum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -8,3 +8,4 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d


### PR DESCRIPTION
This means that the gradle download is not verified.

It is recommend to explicitly setting the expected Sha256sum to protect you and your apps if a bad actor gets access to the Gradle servers or manages to MitM your internet connection.
