### PR TITLE
put a cutout in the scanner UI

### DIFF
--- a/common-app/src/main/res/layout/fragment_qr_scanner.xml
+++ b/common-app/src/main/res/layout/fragment_qr_scanner.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ (C) Copyright IBM Deutschland GmbH 2021
   ~ (C) Copyright IBM Corp. 2021
   -->
@@ -14,14 +13,73 @@
     android:id="@+id/zxing_barcode_scanner"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:zxing_scanner_layout="@layout/custom_barcode_scanner" />
+    app:zxing_scanner_layout="@layout/custom_barcode_scanner">
 
-  <ImageView
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:alpha="0.57"
-    android:background="@color/scanner_overlay"
-    tools:ignore="ContentDescription" />
+    <TableLayout
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:layout_marginBottom="104dp">
+
+      <TableRow
+        android:layout_width="fill_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <ImageView
+          android:layout_width="fill_parent"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:alpha="0.57"
+          android:background="@color/scanner_overlay"
+          tools:ignore="ContentDescription" />
+      </TableRow>
+
+      <TableRow
+        android:layout_width="fill_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1.5">
+
+        <ImageView
+          android:layout_width="fill_parent"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:alpha="0.57"
+          android:background="@color/scanner_overlay"
+          tools:ignore="ContentDescription" />
+
+        <ImageView
+          android:layout_height="fill_parent"
+          android:layout_weight="5"
+          android:alpha="0"
+          android:background="@color/scanner_overlay"
+          tools:ignore="ContentDescription" />
+
+        <ImageView
+          android:layout_width="fill_parent"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:alpha="0.57"
+          android:background="@color/scanner_overlay"
+          tools:ignore="ContentDescription" />
+      </TableRow>
+
+      <TableRow
+        android:layout_width="fill_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <ImageView
+          android:layout_width="fill_parent"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:alpha="0.57"
+          android:background="@color/scanner_overlay"
+          tools:ignore="ContentDescription" />
+      </TableRow>
+
+    </TableLayout>
+
+  </com.journeyapps.barcodescanner.DecoratedBarcodeView>
 
   <FrameLayout
     android:layout_width="match_parent"


### PR DESCRIPTION
This puts a cutout in the UI of the scanner component. Before the whole screen was covered by a dark overlay which may seem unusual to the average user. This PR changes it to a more well-known UI with dark borders and a normal cutout window in the middle.
<!---Description/motivation above this comment please -->

## Ticket id

<!---Mentioning the ticket id automatically links to Jira. -->

EBH-

## Checklist

- [x] The CHANGELOG is up to date with public API changes.
- [x] The documentation is up to date and in a good shape.
- [ ] The unit tests for new code I've added are in a good shape.
- [x] These changes are compatible with R8/ProGuard.
