### PR TITLE
fix autofocus

### DIFF
--- a/common-app/src/main/java/de/rki/covpass/commonapp/scanner/QRScannerFragment.kt
+++ b/common-app/src/main/java/de/rki/covpass/commonapp/scanner/QRScannerFragment.kt
@@ -172,13 +172,20 @@ public abstract class QRScannerFragment : BaseFragment() {
         cameraProvider.unbindAll()
 
         withErrorReporting {
-            camera = cameraProvider.bindToLifecycle(
+            val preparedCamera = cameraProvider.bindToLifecycle(
                 this,
                 cameraSelector,
                 preview,
                 imageCapture,
                 imageAnalyzer
             )
+            val factory = SurfaceOrientedMeteringPointFactory(metrics.width().toFloat(), metrics.height().toFloat())
+            val point = factory.createPoint(metrics.exactCenterX(), metrics.exactCenterX())
+            val action = FocusMeteringAction.Builder(point, FocusMeteringAction.FLAG_AF)
+                .addPoint(point, FocusMeteringAction.FLAG_AE)
+                .build()
+            preparedCamera.cameraControl.startFocusAndMetering(action)
+            camera = preparedCamera
             binding.scannerFlashlightButton.isVisible = hasFlash()
             setTorch(isTorchOn.value)
             preview.setSurfaceProvider(binding.barcodeScanner.surfaceProvider)


### PR DESCRIPTION
Older devices, that are still supported by Android 6+ do not implement continuous in the OS itself. This results in the Camera not being able to scan any QR Codes. Issue first mentioned by #114.

This PR implements an initial autofocus and additionally an on-tap focus.

<!---Description/motivation above this comment please -->

## Checklist

- [x] The CHANGELOG is up to date with public API changes.
- [x] The documentation is up to date and in a good shape.
- [x] The unit tests for new code I've added are in a good shape.
- [x] These changes are compatible with R8/ProGuard.
