### PR TITLE
Feature/migrate gradle plugin dsl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,28 +3,15 @@
  * (C) Copyright IBM Corp. 2021
  */
 
-buildscript {
-    ext.kotlin_version = '1.5.31'
-    repositories {
-        google()
-        mavenCentral()
-        maven { url 'https://jitpack.io' }
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:7.0.3"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.18.1"
-        classpath "pl.allegro.tech.build:axion-release-plugin:1.13.3"
-        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-        classpath "com.jaredsburrows:gradle-license-plugin:0.8.90"
-    }
-}
-
 plugins {
-    id "com.github.ben-manes.versions" version "0.38.0"
+    id 'com.android.application' version '7.0.3' apply false
+    id 'org.jetbrains.kotlin.android' version '1.5.31' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.5.31' apply false
+    id 'io.gitlab.arturbosch.detekt' version '1.18.1' apply false
+    id 'com.jaredsburrows.license' version '0.8.90' apply false
+    id 'pl.allegro.tech.build.axion-release' version '1.13.3'
+    id 'com.github.ben-manes.versions' version '0.38.0'
 }
-
-apply plugin: 'pl.allegro.tech.build.axion-release'
 
 apply from: "$rootDir/gradle/common/repos.gradle"
 setupRepos()

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,9 +20,10 @@ dependencies {
                 // While kotlin-stdlib and kotlin-stdlib-common are automatically set by the gradle plugin,
                 // a few older dependencies still want kotlin-stdlib-jdk7 or kotlin-reflect based on a different Kotlin
                 // version. Make everything consistent and prevent compilation warnings.
-                api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-                api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-                api "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+                def kotlinVersion = "1.5.31"
+                api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+                api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+                api "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
                 api "org.conscrypt:conscrypt-android:2.5.2"
 

--- a/gradle/common/dependency-updates.gradle
+++ b/gradle/common/dependency-updates.gradle
@@ -3,15 +3,17 @@
  * (C) Copyright IBM Corp. 2021
  */
 
-dependencyUpdates.resolutionStrategy {
-    componentSelection { rules ->
-        rules.all { ComponentSelection selection ->
-            boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm'].any { qualifier ->
-                selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
-            }
-            if (rejected) {
-                selection.reject('Release candidate')
-            }
-        }
+dependencyUpdates {
+    gradleReleaseChannel = "current"
+    rejectVersionIf {
+        releaseType(it.candidate.version) < releaseType(it.currentVersion)
     }
+}
+
+static def releaseType(String version) {
+    def sortedReleaseQualifiers = ['alpha', 'beta', 'm', 'rc']
+    def index = sortedReleaseQualifiers.findIndexOf { qualifier ->
+        version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
+    }
+    if (index < 0) return sortedReleaseQualifiers.size() else return index
 }

--- a/gradle/common/repos.gradle
+++ b/gradle/common/repos.gradle
@@ -27,7 +27,12 @@ ext.setupRepos = { Set<RepoType> repos = new HashSet(RepoType.values().toList())
         repositories {
             google()
             mavenCentral()
-            maven { url 'https://jitpack.io' }
+            maven {
+                url 'https://jitpack.io'
+                content {
+                    includeModule 'com.github.instacart.truetime-android', 'library'
+                }
+            }
             mavenLocal()  // since we need this so often, let's just keep it as the last fallback
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,18 @@
-rootProject.name = 'android-covpass-app'
-
 /*
  * (C) Copyright IBM Deutschland GmbH 2021
  * (C) Copyright IBM Corp. 2021
  */
+
+// The pluginManagement {} block must appear before any other statements in the script.
+pluginManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'android-covpass-app'
 
 // SDK modules
 include ':covpass-bom'

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,6 @@ pluginManagement {
     repositories {
         google()
         gradlePluginPortal()
-        mavenCentral()
     }
 }
 


### PR DESCRIPTION
This PR replaces the [Legacy Plugin Application](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application) (which made use of the buildscript block) with the recommended Gradle Plugin DSL. The version numbers remain untouched.

In addition I restricted the _jitpack_ repository to only include the _com.github.instacart.truetime-android_ dependency (which [improves security](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:repository-content-filtering), since no other libraries can be resolved using this repo).

I also [improved](https://github.com/Digitaler-Impfnachweis/covpass-android/pull/154/commits/8bfe29bc7493af4f4d739c12adc929b385f0f2ea) the Gradle Versions Plugin configuration, so that it does not reject pre-release versions in general, but only if the current version type is higher (alpha < beta < m < rc). For example this currently show these 2 updates which previously where rejected.

```
The following dependencies have later milestone versions:
 - androidx.camera:camera-view [1.0.0-alpha30 -> 1.0.0-alpha32]
 - androidx.window:window [1.0.0-alpha09 -> 1.0.0-rc01]
 ```

## Checklist

- [x] The CHANGELOG is up to date with public API changes.
- [x] The documentation is up to date and in a good shape.
- [x] The unit tests for new code I've added are in a good shape.
- [x] These changes are compatible with R8/ProGuard.
