### PR TITLE
Add more details to support 2G+ verification

### DIFF
--- a/common-app-covpass-check/src/main/java/de/rki/covpass/checkapp/scanner/CovPassCheckQRScannerFragment.kt
+++ b/common-app-covpass-check/src/main/java/de/rki/covpass/checkapp/scanner/CovPassCheckQRScannerFragment.kt
@@ -5,6 +5,7 @@
 
 package de.rki.covpass.checkapp.scanner
 
+import android.icu.text.RelativeDateTimeFormatter
 import com.ensody.reactivestate.android.reactiveState
 import com.ibm.health.common.navigation.android.FragmentNav
 import com.ibm.health.common.navigation.android.findNavigator
@@ -17,6 +18,8 @@ import de.rki.covpass.sdk.cert.models.CovCertificate
 import de.rki.covpass.sdk.utils.formatDate
 import kotlinx.parcelize.Parcelize
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeParseException
 
@@ -42,11 +45,15 @@ internal class CovPassCheckQRScannerFragment :
     }
 
     override fun onValidationSuccess(certificate: CovCertificate) {
+        var vaccinationDate = certificate.vaccination?.occurrence;
+        var vaccinationDatePeriod = vaccinationDate?.until(LocalDate.now());
         findNavigator().push(
             ValidationResultSuccessNav(
                 certificate.fullName,
                 certificate.fullTransliteratedName,
-                formatDate(certificate.birthDateFormatted)
+                formatDate(certificate.birthDateFormatted),
+                vaccinationDatePeriod?.months,
+                certificate.vaccination?.isBooster ?: false,
             )
         )
     }

--- a/common-app-covpass-check/src/main/java/de/rki/covpass/checkapp/validation/ValidationResultFragment.kt
+++ b/common-app-covpass-check/src/main/java/de/rki/covpass/checkapp/validation/ValidationResultFragment.kt
@@ -120,6 +120,8 @@ internal class ValidationResultSuccessNav(
     val name: String,
     val transliteratedName: String,
     val birthDate: String,
+    val vaccinationNumberOfMonthsAgo: Int?,
+    val isBooster : Boolean,
 ) : FragmentNav(ValidationResultSuccessFragment::class)
 
 /**
@@ -138,12 +140,20 @@ internal class ValidationResultSuccessFragment : ValidationResultFragment() {
     override val titleInfo1 by lazy { args.name }
     override val subtitleInfo1 by lazy { args.transliteratedName }
     override val textInfo1 by lazy {
-        getString(R.string.validation_check_popup_valid_vaccination_date_of_birth, args.birthDate)
+        getString(R.string.validation_check_popup_valid_vaccination_date_of_birth, args.birthDate) +
+        if (args.vaccinationNumberOfMonthsAgo != null) {
+            "\n" +
+                getString(R.string.validation_check_popup_valid_vaccination_date, args.vaccinationNumberOfMonthsAgo)
+        } else ""
     }
     override val imageInfo1Res = R.drawable.result_person
 
     override val textFooter by lazy {
-        getString(R.string.validation_check_popup_valid_vaccination_recovery_note)
+        if (args.isBooster) {
+            getString(R.string.validation_check_popup_valid_vaccination_booster)
+        } else {
+            getString(R.string.validation_check_popup_valid_vaccination_recovery_note)
+        }
     }
 
     override val buttonTextRes = R.string.validation_check_popup_valid_vaccination_button_title

--- a/common-app-covpass-check/src/main/res/values/generated_strings.xml
+++ b/common-app-covpass-check/src/main/res/values/generated_strings.xml
@@ -75,7 +75,9 @@
 	<string name="validation_check_popup_valid_vaccination_recovery_title">Certificate valid*</string>
 	<string name="validation_check_popup_valid_vaccination_recovery_message">Check the following data against an ID document from the person you are checking.</string>
 	<string name="validation_check_popup_valid_vaccination_date_of_birth">Born on %s</string>
+  <string name="validation_check_popup_valid_vaccination_date">Vaccinated %d months ago</string>
 	<string name="validation_check_popup_valid_vaccination_recovery_note">* Person has recovery or vaccination certificate.</string>
+	<string name="validation_check_popup_valid_vaccination_booster">* Person has valid booster vaccination.</string>
 	<string name="technical_validation_check_popup_unsuccessful_certificate_title">Certificate not valid</string>
 	<string name="technical_validation_check_popup_unsuccessful_certificate_subline">The certificate is invalid for one of the following reasons:</string>
 	<string name="technical_validation_check_popup_unsuccessful_certificate_signature_subheading">Invalid signature</string>


### PR DESCRIPTION
In e.g. Baden-Wuerttemberg, we have a 2G+ rule. This means you need to be vaccinated and tested, except if your last vaccination was less than 6 months ago or you got a booster shot since.

This use case currently can't be supported by the CovPass Check app, as it only shows *if* someone is vaccinated/recovered, but not how long ago it was or whether it was a booster. This currently forces people to scan the barcode and then check details of the vaccination certificate on other people's smartphones, which is not secure at all and also not very hygienic.

All the required data to check these rules is actually already contained in the QR code, but just not displayed to the user.

The code can be much improved upon, the goal of this PR is to get the discussion around this feature started as it seems to me it was a conscious decision to display as little details on the certificate as possible. If the idea gets accepted, I can further improve upon the code. Comments welcome, as I am not a Kotlin nor Android developer. I could also use some help with writing unit tests for my feature, as I was unable to find tests outside the covpass-sdk. 

<!---Description/motivation above this comment please -->

## Ticket id

<!---Mentioning the ticket id automatically links to Jira. -->

EBH-

## Checklist

- [x] The CHANGELOG is up to date with public API changes. -> no changes
- [ ] The documentation is up to date and in a good shape.
- [ ] The unit tests for new code I've added are in a good shape. -> needs help
- [ ] These changes are compatible with R8/ProGuard. -> needs help
